### PR TITLE
[vue] Change path to match default inertia.js path

### DIFF
--- a/docs/guide/pages.md
+++ b/docs/guide/pages.md
@@ -429,7 +429,7 @@ If you're using persistent layouts, you may find it convenient to define the def
 
 ```js
 // frontend/entrypoints/inertia.js
-import Layout from './Layout'
+import Layout from '../Layout'
 
 createInertiaApp({
   resolve: (name) => {
@@ -462,12 +462,13 @@ createInertiaApp({
 == React
 
 ```js
-import Layout from './Layout'
+// frontend/entrypoints/inertia.js
+import Layout from '../Layout'
 
 createInertiaApp({
   resolve: (name) => {
-    const pages = import.meta.glob('./pages/**/*.jsx', { eager: true })
-    let page = pages[`./pages/${name}.jsx`]
+    const pages = import.meta.glob('../pages/**/*.jsx', { eager: true })
+    let page = pages[`../pages/${name}.jsx`]
     page.default.layout =
       page.default.layout || ((page) => <Layout children={page} />)
     return page
@@ -479,12 +480,13 @@ createInertiaApp({
 == Svelte
 
 ```js
-import Layout from './Layout'
+// frontend/entrypoints/inertia.js
+import Layout from '../Layout'
 
 createInertiaApp({
   resolve: (name) => {
-    const pages = import.meta.glob('./pages/**/*.svelte', { eager: true })
-    let page = pages[`./pages/${name}.svelte`]
+    const pages = import.meta.glob('../pages/**/*.svelte', { eager: true })
+    let page = pages[`../pages/${name}.svelte`]
     return { default: page.default, layout: page.layout || Layout }
   },
   // ...
@@ -502,7 +504,7 @@ You can even go a step further and conditionally set the default page layout bas
 
 ```js
 // frontend/entrypoints/inertia.js
-import Layout from './Layout'
+import Layout from '../Layout'
 
 createInertiaApp({
   resolve: (name) => {
@@ -519,7 +521,7 @@ createInertiaApp({
 
 ```js
 // frontend/entrypoints/inertia.js
-import Layout from './Layout'
+import Layout from '../Layout'
 
 createInertiaApp({
   resolve: (name) => {
@@ -535,12 +537,13 @@ createInertiaApp({
 == React
 
 ```js
-import Layout from './Layout'
+// frontend/entrypoints/inertia.js
+import Layout from '../Layout'
 
 createInertiaApp({
   resolve: (name) => {
     const pages = import.meta.glob('./pages/**/*.jsx', { eager: true })
-    let page = pages[`./pages/${name}.jsx`]
+    let page = pages[`../pages/${name}.jsx`]
     page.default.layout = name.startsWith('Public/')
       ? undefined
       : (page) => <Layout children={page} />
@@ -553,12 +556,13 @@ createInertiaApp({
 == Svelte
 
 ```js
-import Layout from './Layout'
+// frontend/entrypoints/inertia.js
+import Layout from '../Layout'
 
 createInertiaApp({
   resolve: (name) => {
-    const pages = import.meta.glob('./pages/**/*.svelte', { eager: true })
-    let page = pages[`./pages/${name}.svelte`]
+    const pages = import.meta.glob('../pages/**/*.svelte', { eager: true })
+    let page = pages[`../pages/${name}.svelte`]
     return {
       default: page.default,
       layout: name.startsWith('Public/') ? undefined : Layout,

--- a/docs/guide/pages.md
+++ b/docs/guide/pages.md
@@ -428,12 +428,13 @@ If you're using persistent layouts, you may find it convenient to define the def
 == Vue 2
 
 ```js
+// frontend/entrypoints/inertia.js
 import Layout from './Layout'
 
 createInertiaApp({
   resolve: (name) => {
-    const pages = import.meta.glob('./pages/**/*.vue', { eager: true })
-    let page = pages[`./pages/${name}.vue`]
+    const pages = import.meta.glob('../pages/**/*.vue', { eager: true })
+    let page = pages[`../pages/${name}.vue`]
     page.default.layout = page.default.layout || Layout
     return page
   },
@@ -444,12 +445,13 @@ createInertiaApp({
 == Vue 3
 
 ```js
+// frontend/entrypoints/inertia.js
 import Layout from './Layout'
 
 createInertiaApp({
   resolve: (name) => {
-    const pages = import.meta.glob('./pages/**/*.vue', { eager: true })
-    let page = pages[`./pages/${name}.vue`]
+    const pages = import.meta.glob('../pages/**/*.vue', { eager: true })
+    let page = pages[`../pages/${name}.vue`]
     page.default.layout = page.default.layout || Layout
     return page
   },
@@ -499,12 +501,13 @@ You can even go a step further and conditionally set the default page layout bas
 == Vue 2
 
 ```js
+// frontend/entrypoints/inertia.js
 import Layout from './Layout'
 
 createInertiaApp({
   resolve: (name) => {
-    const pages = import.meta.glob('./pages/**/*.vue', { eager: true })
-    let page = pages[`./pages/${name}.vue`]
+    const pages = import.meta.glob('../pages/**/*.vue', { eager: true })
+    let page = pages[`../pages/${name}.vue`]
     page.default.layout = name.startsWith('Public/') ? undefined : Layout
     return page
   },
@@ -515,12 +518,13 @@ createInertiaApp({
 == Vue 3
 
 ```js
+// frontend/entrypoints/inertia.js
 import Layout from './Layout'
 
 createInertiaApp({
   resolve: (name) => {
-    const pages = import.meta.glob('./pages/**/*.vue', { eager: true })
-    let page = pages[`./pages/${name}.vue`]
+    const pages = import.meta.glob('../pages/**/*.vue', { eager: true })
+    let page = pages[`../pages/${name}.vue`]
     page.default.layout = name.startsWith('Public/') ? undefined : Layout
     return page
   },


### PR DESCRIPTION
In the docs it seems assume `createInertiaApp` is located in a file in the same level as pages folder. But in actual, we have to go up one directory to access pages, hence if we copy and paste the default layout from the documentation, the page will failed.

p/s: Not sure about other framework  setup. Also thanks for the updated rails inertia documentation !