### PR TITLE
changes vite ruby to vite rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ### Installation generator
 
-`InertiaRailsContrib` comes with a generator that installs and sets up Inertia in a Rails application. **It requires the [Vite Ruby](https://vite-ruby.netlify.app) gem to be installed and configured in the application.**
+`InertiaRailsContrib` comes with a generator that installs and sets up Inertia in a Rails application. **It requires the [Vite Rails](https://vite-ruby.netlify.app/guide/rails.html) gem to be installed and configured in the application.**
 
 <details>
 <summary>Creating a new Rails application and configuring Vite</summary>
@@ -30,7 +30,7 @@ This is actually a simple process. First, create a new Rails application:
 rails new myapp --skip-js
 ```
 
-Next, install the Vite Ruby gem:
+Next, install the Vite Rails gem:
 
 ```bash
 bundle add vite_rails

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ rails new myapp --skip-js
 Next, install the Vite Ruby gem:
 
 ```bash
-bundle add vite_ruby
+bundle add vite_rails
 bundle exec vite install
 ```
 

--- a/docs/guide/server-side-setup.md
+++ b/docs/guide/server-side-setup.md
@@ -15,7 +15,7 @@ bundle add inertia_rails
 
 ## Rails generator
 
-If you plan to use Vite as your frontend build tool, you can use the `inertia_rails-contrib` gem to install and set up Inertia in a Rails application. **It requires the [Vite Ruby](https://vite-ruby.netlify.app) gem to be installed and configured in the application.**
+If you plan to use Vite as your frontend build tool, you can use the `inertia_rails-contrib` gem to install and set up Inertia in a Rails application. **It requires the [Vite Rails](https://vite-ruby.netlify.app/guide/rails.html) gem to be installed and configured in the application.**
 
 To use the generator, execute the following command in the terminal:
 


### PR DESCRIPTION
When I have tried to set up a new rails application with `inertia_rails-contrib` and `vite_ruby` it fails.

I followed the step by step the README.md with `vite_rails` and it worked perfectly, so I guess the correct gem to everything works is `vite_rails` 

PS: Sorry for the flood of Prs :smile: 