### PR TITLE
Add support tailwind.config.ts in generators helper

### DIFF
--- a/lib/inertia_rails_contrib/generators_helper.rb
+++ b/lib/inertia_rails_contrib/generators_helper.rb
@@ -14,7 +14,7 @@ module InertiaRailsContrib
     end
 
     def self.guess_inertia_template
-      if Rails.root.join("tailwind.config.js").exist?
+      if Rails.root.join("tailwind.config.js").exist? || Rails.root.join("tailwind.config.ts").exist?
         "inertia_tw_templates"
       else
         "inertia_templates"


### PR DESCRIPTION
Added `Rails.root.join("tailwind.config.ts").exist?` to `guess_inertia_template` method so that it can detect tailwind templates for people using `tailwind.config.ts`