### PR TITLE
Return the Modal ID

### DIFF
--- a/lib/inertia_rails_contrib/inertia_ui_modal.rb
+++ b/lib/inertia_rails_contrib/inertia_ui_modal.rb
@@ -8,6 +8,7 @@ module InertiaRailsContrib
   module InertiaUIModal
     HEADER_BASE_URL = "X-InertiaUI-Modal-Base-Url"
     HEADER_USE_ROUTER = "X-InertiaUI-Modal-Use-Router"
+    HEADER_MODAL = "X-InertiaUI-Modal"
   end
 end
 

--- a/lib/inertia_rails_contrib/inertia_ui_modal/renderer.rb
+++ b/lib/inertia_rails_contrib/inertia_ui_modal/renderer.rb
@@ -18,6 +18,7 @@ module InertiaRailsContrib
         end
 
         page = @inertia_renderer.page
+        page[:id] = modal_id if modal_id.present?
         page[:baseUrl] = base_url
         page[:meta] = {
           deferredProps: page.delete(:deferredProps),
@@ -31,6 +32,10 @@ module InertiaRailsContrib
 
       def base_url
         @request.headers[HEADER_BASE_URL] || @base_url
+      end
+
+      def modal_id
+        @modal_id ||= @request.headers[HEADER_MODAL]
       end
 
       def render_base_url

--- a/spec/integration/inertiaui_modal_spec.rb
+++ b/spec/integration/inertiaui_modal_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe "InertiaUI Modal Integration", type: :request do
       expect(response.parsed_body).to eq(expected_page.as_json)
     end
 
+    it "returns modal ID prop when provided" do
+      get "/modal", headers: {
+        "X-Inertia" => "true",
+        "X-Inertia-Version" => "1",
+        "X-InertiaUI-Modal" => "inertiaui_modal_198a8978-df9e-41c5-97ea-cd100651e80e"
+      }
+
+      expected_modal[:id] = "inertiaui_modal_198a8978-df9e-41c5-97ea-cd100651e80e"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(expected_page.as_json)
+    end
+
     it "returns only deferred props when requested" do
       get "/modal", headers: {
         "X-Inertia" => "true",


### PR DESCRIPTION
# Description
This is a bug fix: When using the [navigate](https://inertiaui.com/inertia-modal/docs/base-route-url#open-a-modal-with-a-base-route) option, a modal could not be opened more than once. This is because the modal is stuck in an indefinite "loading" state due to a promise which is never resolved for the modal instance. Inertia Modal expects the ID to be passed as a prop, then performs a hash lookup for the promise to resolve.

This PR returns the modal ID as a prop if the header is provided.

Here is the equivalent code in the main project's Laravel library: https://github.com/inertiaui/modal/blob/7aed80af5d8b9d777b6eede006c641836d1bd2cc/src/Modal.php#L127



**Side note:** I'm using a custom built Svelte 5 implementation which is based on the Vue implementation.