### PR TITLE
Align InertiaUI Modal with upstream v2/v3

### DIFF
--- a/lib/inertia_rails_contrib/inertia_ui_modal.rb
+++ b/lib/inertia_rails_contrib/inertia_ui_modal.rb
@@ -7,7 +7,6 @@ require_relative "inertia_ui_modal/inertia_rails_patch"
 module InertiaRailsContrib
   module InertiaUIModal
     HEADER_BASE_URL = "X-InertiaUI-Modal-Base-Url"
-    HEADER_USE_ROUTER = "X-InertiaUI-Modal-Use-Router"
     HEADER_MODAL = "X-InertiaUI-Modal"
   end
 end

--- a/lib/inertia_rails_contrib/inertia_ui_modal/inertia_rails_patch.rb
+++ b/lib/inertia_rails_contrib/inertia_ui_modal/inertia_rails_patch.rb
@@ -24,12 +24,9 @@ module InertiaRailsContrib
 
       def extract_meta!(modal)
         meta = {}
-        %i[mergeProps deferredProps cache].each do |key|
-          next unless modal.key?(key)
-
-          meta[key] = modal.delete(key)
+        InertiaRailsContrib::InertiaUIModal::Renderer::META_KEYS.each do |key|
+          meta[key] = modal.delete(key) if modal.key?(key)
         end
-
         modal[:meta] = meta
       end
     end

--- a/lib/inertia_rails_contrib/inertia_ui_modal/renderer.rb
+++ b/lib/inertia_rails_contrib/inertia_ui_modal/renderer.rb
@@ -12,18 +12,17 @@ module InertiaRailsContrib
         @inertia_renderer = InertiaRails::Renderer.new(component, controller, request, response, render_method, **options.slice(*KNOWN_KEYWORDS))
       end
 
+      META_KEYS = %i[mergeProps deferredProps].freeze
+
       def render
-        if !render_on_base_url?
+        if modal_request? || base_url.blank?
           return @inertia_renderer.render
         end
 
         page = @inertia_renderer.page
         page[:id] = modal_id if modal_id.present?
         page[:baseUrl] = base_url
-        page[:meta] = {
-          deferredProps: page.delete(:deferredProps),
-          mergeProps: page.delete(:mergeProps)
-        }
+        page[:meta] = extract_meta(page)
 
         @request.env[:_inertiaui_modal] = page
 
@@ -34,16 +33,22 @@ module InertiaRailsContrib
         @request.headers[HEADER_BASE_URL] || @base_url
       end
 
-      def render_on_base_url?
-        return false if base_url.blank?
-        return true if @request.headers[HEADER_USE_ROUTER] == "1"
-        return false if @request.headers[HEADER_USE_ROUTER] == "0"
-
-        modal_id.blank?
+      def modal_request?
+        modal_id.present?
       end
 
       def modal_id
         @modal_id ||= @request.headers[HEADER_MODAL]
+      end
+
+      private
+
+      def extract_meta(page)
+        meta = {}
+        META_KEYS.each do |key|
+          meta[key] = page.delete(key) if page.key?(key)
+        end
+        meta
       end
 
       def render_base_url

--- a/lib/inertia_rails_contrib/inertia_ui_modal/renderer.rb
+++ b/lib/inertia_rails_contrib/inertia_ui_modal/renderer.rb
@@ -15,8 +15,6 @@ module InertiaRailsContrib
       META_KEYS = %i[mergeProps deferredProps].freeze
 
       def render
-        # If the base URL route returns a modal, render it as a plain Inertia
-        # response to prevent infinite recursion (upstream #115)
         if @request.env[:_inertiaui_modal_base_dispatch] || modal_request? || base_url.blank?
           return @inertia_renderer.render
         end
@@ -32,7 +30,9 @@ module InertiaRailsContrib
       end
 
       def base_url
-        @request.headers[HEADER_BASE_URL] || @base_url
+        return @resolved_base_url if defined?(@resolved_base_url)
+
+        @resolved_base_url = resolve_base_url
       end
 
       def modal_request?
@@ -44,6 +44,29 @@ module InertiaRailsContrib
       end
 
       private
+
+      def resolve_base_url
+        candidates = [
+          @request.headers[HEADER_BASE_URL],
+          @request.referer,
+          @base_url
+        ]
+
+        current = normalize_path(@request.path)
+
+        candidates.each do |candidate|
+          next if candidate.nil?
+          next if normalize_path(URI.parse(candidate).path) == current
+
+          return candidate
+        end
+
+        nil
+      end
+
+      def normalize_path(path)
+        CGI.unescape(path.to_s.delete_prefix("/").delete_suffix("/"))
+      end
 
       def extract_meta(page)
         meta = {}

--- a/lib/inertia_rails_contrib/inertia_ui_modal/renderer.rb
+++ b/lib/inertia_rails_contrib/inertia_ui_modal/renderer.rb
@@ -15,7 +15,9 @@ module InertiaRailsContrib
       META_KEYS = %i[mergeProps deferredProps].freeze
 
       def render
-        if modal_request? || base_url.blank?
+        # If the base URL route returns a modal, render it as a plain Inertia
+        # response to prevent infinite recursion (upstream #115)
+        if @request.env[:_inertiaui_modal_base_dispatch] || modal_request? || base_url.blank?
           return @inertia_renderer.render
         end
 
@@ -58,6 +60,7 @@ module InertiaRailsContrib
         end
 
         request_to_base = ActionDispatch::Request.new(original_env)
+        request_to_base.env[:_inertiaui_modal_base_dispatch] = true
 
         path = ActionDispatch::Journey::Router::Utils.normalize_path(request_to_base.path_info)
         Rails.application.routes.recognize_path_with_request(request_to_base, path, {})

--- a/spec/integration/inertiaui_modal_spec.rb
+++ b/spec/integration/inertiaui_modal_spec.rb
@@ -137,6 +137,26 @@ RSpec.describe "InertiaUI Modal Integration", type: :request do
     end
   end
 
+  describe "when base URL returns another modal" do
+    it "renders without infinite recursion" do
+      get "/nested_modal"
+
+      expect(response.status).to eq(200)
+      page = page_data
+      expect(page["component"]).to eq("base_modal")
+      expect(page["props"]).to have_key("_inertiaui_modal")
+      expect(page["props"]["_inertiaui_modal"]["component"]).to eq("nested_modal")
+    end
+
+    def page_data
+      doc = Nokogiri::HTML(response.body)
+      data_page = doc.at_css("#app")&.[]("data-page")
+      return nil unless data_page
+
+      JSON.parse(CGI.unescapeHTML(data_page))
+    end
+  end
+
   describe "when base URL uses other param names" do
     it "receives correct parameters from base URL" do
       get "/projects/789/tasks/456"

--- a/spec/integration/inertiaui_modal_spec.rb
+++ b/spec/integration/inertiaui_modal_spec.rb
@@ -3,6 +3,14 @@
 require "spec_helper"
 
 RSpec.describe "InertiaUI Modal Integration", type: :request do
+  def page_data
+    doc = Nokogiri::HTML(response.body)
+    data_page = doc.at_css("#app")&.[]("data-page")
+    return nil unless data_page
+
+    JSON.parse(CGI.unescapeHTML(data_page))
+  end
+
   describe "GET /modal" do
     let(:expected_modal) do
       {
@@ -110,14 +118,6 @@ RSpec.describe "InertiaUI Modal Integration", type: :request do
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq(expected_defer_modal.as_json)
     end
-
-    def page_data
-      doc = Nokogiri::HTML(response.body)
-      data_page = doc.at_css("#app")&.[]("data-page")
-      return nil unless data_page
-
-      JSON.parse(CGI.unescapeHTML(data_page))
-    end
   end
 
   describe "when base URL controller uses implicit rendering" do
@@ -126,14 +126,6 @@ RSpec.describe "InertiaUI Modal Integration", type: :request do
 
       expect(response.status).to eq(200)
       expect(page_data).to include("component" => "base")
-    end
-
-    def page_data
-      doc = Nokogiri::HTML(response.body)
-      data_page = doc.at_css("#app")&.[]("data-page")
-      return nil unless data_page
-
-      JSON.parse(CGI.unescapeHTML(data_page))
     end
   end
 
@@ -147,13 +139,75 @@ RSpec.describe "InertiaUI Modal Integration", type: :request do
       expect(page["props"]).to have_key("_inertiaui_modal")
       expect(page["props"]["_inertiaui_modal"]["component"]).to eq("nested_modal")
     end
+  end
 
-    def page_data
-      doc = Nokogiri::HTML(response.body)
-      data_page = doc.at_css("#app")&.[]("data-page")
-      return nil unless data_page
+  describe "resolving base URL" do
+    it "prioritizes header over referer and configured base_url" do
+      get "/modal_with_base", headers: {
+        "X-InertiaUI-Modal-Base-Url" => "/base",
+        "Referer" => "http://www.example.com/somewhere_else"
+      }
 
-      JSON.parse(CGI.unescapeHTML(data_page))
+      expect(response.status).to eq(200)
+      modal_data = page_data["props"]["_inertiaui_modal"]
+      expect(modal_data["baseUrl"]).to eq("/base")
+    end
+
+    it "falls back to referer when no header and no configured base_url" do
+      get "/modal_no_base", headers: {
+        "Referer" => "http://www.example.com/base"
+      }
+
+      expect(response.status).to eq(200)
+      modal_data = page_data["props"]["_inertiaui_modal"]
+      expect(modal_data["baseUrl"]).to eq("http://www.example.com/base")
+    end
+
+    it "skips header when it matches current path" do
+      get "/modal_with_base", headers: {
+        "X-InertiaUI-Modal-Base-Url" => "/modal_with_base",
+        "Referer" => "http://www.example.com/base"
+      }
+
+      expect(response.status).to eq(200)
+      modal_data = page_data["props"]["_inertiaui_modal"]
+      expect(modal_data["baseUrl"]).to eq("http://www.example.com/base")
+    end
+
+    it "skips referer when it matches current path" do
+      get "/modal_with_base", headers: {
+        "Referer" => "http://www.example.com/modal_with_base"
+      }
+
+      expect(response.status).to eq(200)
+      modal_data = page_data["props"]["_inertiaui_modal"]
+      expect(modal_data["baseUrl"]).to eq("/base")
+    end
+
+    it "returns direct modal when no base URL can be resolved" do
+      get "/modal_no_base"
+
+      expect(response.status).to eq(200)
+      expect(page_data["component"]).to eq("modal_no_base")
+      expect(page_data["props"]).not_to have_key("_inertiaui_modal")
+    end
+
+    it "returns direct modal when referer matches current path and no configured base_url" do
+      get "/modal_no_base", headers: {
+        "Referer" => "http://www.example.com/modal_no_base"
+      }
+
+      expect(response.status).to eq(200)
+      expect(page_data["component"]).to eq("modal_no_base")
+      expect(page_data["props"]).not_to have_key("_inertiaui_modal")
+    end
+
+    it "skips configured base_url when it matches current path" do
+      get "/modal_self_base"
+
+      expect(response.status).to eq(200)
+      expect(page_data["component"]).to eq("modal_self_base")
+      expect(page_data["props"]).not_to have_key("_inertiaui_modal")
     end
   end
 

--- a/spec/integration/inertiaui_modal_spec.rb
+++ b/spec/integration/inertiaui_modal_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe "InertiaUI Modal Integration", type: :request do
         url: "/modal",
         version: "1",
         encryptHistory: false,
-        clearHistory: false
+        clearHistory: false,
+        id: "inertiaui_modal_1234",
+        meta: {}
       }
     end
 
@@ -83,18 +85,7 @@ RSpec.describe "InertiaUI Modal Integration", type: :request do
       expect(response.parsed_body).to eq(expected_page.as_json)
     end
 
-    it "returns base & modal merged together when explicitly requested with X-InertiaUI-Modal-Use-Router: 1" do
-      get "/modal", headers: {
-        "X-Inertia" => "true",
-        "X-Inertia-Version" => "1",
-        "X-InertiaUI-Modal-Use-Router" => "1"
-      }
-
-      expect(response.status).to eq(200)
-      expect(response.parsed_body).to eq(expected_page.as_json)
-    end
-
-    it "returns modal ID prop when provided" do
+    it "returns modal response when X-InertiaUI-Modal header is present" do
       get "/modal", headers: {
         "X-Inertia" => "true",
         "X-Inertia-Version" => "1",
@@ -107,11 +98,11 @@ RSpec.describe "InertiaUI Modal Integration", type: :request do
       )
     end
 
-    it "returns only deferred props when requested" do
+    it "returns only deferred props when requested with X-InertiaUI-Modal header" do
       get "/modal", headers: {
         "X-Inertia" => "true",
         "X-Inertia-Version" => "1",
-        "X-InertiaUI-Modal-Use-Router" => "0",
+        "X-InertiaUI-Modal" => "inertiaui_modal_1234",
         "X-Inertia-Partial-Component" => "modal",
         "X-Inertia-Partial-Data" => "deferred_param"
       }

--- a/spec/internal/app/controllers/test_controller.rb
+++ b/spec/internal/app/controllers/test_controller.rb
@@ -25,4 +25,16 @@ class TestController < ActionController::Base
   def nested_modal
     render inertia_modal: "nested_modal", props: {nested: "prop"}, base_url: "/modal_base"
   end
+
+  def modal_with_base
+    render inertia_modal: "modal_with_base", props: {hello: "modal"}, base_url: "/base"
+  end
+
+  def modal_no_base
+    render inertia_modal: "modal_no_base", props: {hello: "modal"}
+  end
+
+  def modal_self_base
+    render inertia_modal: "modal_self_base", props: {hello: "modal"}, base_url: "/modal_self_base"
+  end
 end

--- a/spec/internal/app/controllers/test_controller.rb
+++ b/spec/internal/app/controllers/test_controller.rb
@@ -15,4 +15,14 @@ class TestController < ActionController::Base
       merge_param: InertiaRails.defer(group: "custom", merge: true) { {additional: "data"} }
     }, base_url: "/base"
   end
+
+  # Base URL route that itself returns a modal (for recursion guard test)
+  def modal_base
+    render inertia_modal: "base_modal", props: {base_modal: "prop"}, base_url: "/base"
+  end
+
+  # Modal whose base URL points to another modal route
+  def nested_modal
+    render inertia_modal: "nested_modal", props: {nested: "prop"}, base_url: "/modal_base"
+  end
 end

--- a/spec/internal/config/initializers/inertia_rails.rb
+++ b/spec/internal/config/initializers/inertia_rails.rb
@@ -2,6 +2,7 @@
 
 InertiaRails.configure do |config|
   config.version = "1"
+  config.always_include_errors_hash = false
 end
 
 InertiaRailsContrib.configure do |config|

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   get "/modal", to: "test#modal"
   get "/modal_base", to: "test#modal_base"
   get "/nested_modal", to: "test#nested_modal"
+  get "/modal_with_base", to: "test#modal_with_base"
+  get "/modal_no_base", to: "test#modal_no_base"
+  get "/modal_self_base", to: "test#modal_self_base"
 
   # Routes for testing implicit rendering on base URL
   get "/implicit_base", to: "implicit#base"

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -3,6 +3,8 @@
 Rails.application.routes.draw do
   get "/base", to: "test#base"
   get "/modal", to: "test#modal"
+  get "/modal_base", to: "test#modal_base"
+  get "/nested_modal", to: "test#nested_modal"
 
   # Routes for testing implicit rendering on base URL
   get "/implicit_base", to: "implicit#base"


### PR DESCRIPTION
 Brings the InertiaUI Modal integration in line with the upstream [inertiaui/modal 3.x](https://github.com/inertiaui/modal/compare/f781cfe...1557112) PHP implementation.

### Changes

- **`resolveBaseUrl` with referer fallback and loop prevention** — checks header → referer → configured `base_url`, skipping any candidate whose path matches the current request to prevent infinite loops
- **Recursion guard** — if the base URL route itself returns a modal, renders it as a plain Inertia response instead of dispatching another base URL request
- **Remove `X-InertiaUI-Modal-Use-Router`** — dead header not sent by v2/v3 clients, replace with `X-InertiaUI-Modal` presence check